### PR TITLE
fix: pin npx autocorrect to autocorrect-node

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
 
     - name: Autocorrect zh-cn
       glob: "{docs,files}/zh-cn/*.md"
-      run: npx autocorrect --fix {staged_files}
+      run: npx autocorrect-node --fix {staged_files}
       stage_fixed: true
 
     - name: Format markdown


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

- `.lefthook.yml`: `npx autocorrect --fix {staged_files}` → `npx autocorrect-node --fix {staged_files}`

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

Prevent a dependency-confusion fallback in `npx autocorrect`.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

`npx autocorrect` resolves to the local bin only when present; otherwise npm silently downloads and runs the registry package literally named `autocorrect` — an unrelated string-matching library, not the intended linter. The intended linter ships as `autocorrect-node` (already a pinned dependency), providing the `autocorrect` bin. In lefthook hooks, `npx` assumes `--yes`, so the fallback fetch happens with no prompt. The `yarn autocorrect` calls in `package.json` are unaffected (yarn resolves the local bin) and left unchanged.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Part of https://github.com/mdn/fred/issues/1680.
